### PR TITLE
refactor(nav): use resource_path instead of resource_url

### DIFF
--- a/storefront/app/views/themes/default/spree/page_sections/nav/_desktop.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/nav/_desktop.html.erb
@@ -4,7 +4,7 @@
     <% main_link = presenter.main_link %>
     <% next unless main_link.present? %>
     <div class="header--nav-item group" <%= block_attributes(block, allowed_styles: ['padding-top', 'padding-bottom']) %>>
-      <%= active_link_to spree_storefront_resource_path(main_link.linkable || main_link), data: { title: main_link.label.downcase.strip }, class: "shrink-0 menu-item header--nav-link px-4 py-1", class_active: "menu-item--active", target: main_link.open_in_new_tab.presence && "_blank", rel: main_link.open_in_new_tab.presence && "noopener noreferrer" do %>
+      <%= active_link_to spree_storefront_resource_url(main_link.linkable || main_link, relative: true), data: { title: main_link.label.downcase.strip }, class: "shrink-0 menu-item header--nav-link px-4 py-1", class_active: "menu-item--active", target: main_link.open_in_new_tab.presence && "_blank", rel: main_link.open_in_new_tab.presence && "noopener noreferrer" do %>
         <span class="group-hover:border-b-[1.5px] group-hover:border-b-accent"><%= main_link.label %></span>
       <% end %>
       <% if presenter.columns.any? %>
@@ -21,14 +21,14 @@
                       <% end %>
                     </div>
                   <% end %>
-                  <%= link_to Spree.t(:view_all), spree_storefront_resource_path(column.view_all_linkable), class: "py-3 px-2 uppercase text-sm inline-block tracking-widest font-semibold" %>
+                  <%= link_to Spree.t(:view_all), spree_storefront_resource_url(column.view_all_linkable, relative: true), class: "py-3 px-2 uppercase text-sm inline-block tracking-widest font-semibold" %>
                 </div>
               <% end %>
               <% if block.try(:featured_taxon) %>
                 <% cache spree_base_cache_scope.call(block.featured_taxon) do %>
                   <% if block.featured_taxon.image.attached? && block.featured_taxon.image.variable? %>
-                    <%= link_to spree_storefront_resource_path(block.featured_taxon), class: "flex flex-col col-start-4" do %>
                       <%= image_tag main_app.cdn_image_path(block.featured_taxon.image.variant(spree_image_variant_options(resize_to_fill: [700, 700]))), class: 'w-full h-auto aspect-1', loading: :lazy, alt: block.featured_taxon.name %>
+                    <%= link_to spree_storefront_resource_url(block.featured_taxon, relative: true), class: "flex flex-col col-start-4" do %>
                       <span class="py-3 px-2 bg-accent block uppercase text-sm tracking-widest font-semibold header--mega-nav-featured-taxon-title"><%= Spree.t(:explore_taxon, taxon_name: block.featured_taxon.name) %></span>
                     <% end %>
                   <% end %>
@@ -42,7 +42,7 @@
   <% end %>
 <% else %>
   <% section.links.each do |link| %>
-    <%= active_link_to spree_storefront_resource_path(link.linkable || link), data: { title: link.label.downcase.strip }, class: "shrink-0 menu-item header--nav-link px-4 py-1 focus:mx-0 focus:px-4", class_active: "menu-item--active", target: link.open_in_new_tab.presence && "_blank", rel: link.open_in_new_tab.presence && "noopener noreferrer", **link_attributes(link, as_html: false) do %>
+    <%= active_link_to spree_storefront_resource_url(link.linkable || link, relative: true), data: { title: link.label.downcase.strip }, class: "shrink-0 menu-item header--nav-link px-4 py-1 focus:mx-0 focus:px-4", class_active: "menu-item--active", target: link.open_in_new_tab.presence && "_blank", rel: link.open_in_new_tab.presence && "noopener noreferrer", **link_attributes(link, as_html: false) do %>
       <span><%= link.label %></span>
     <% end %>
   <% end %>

--- a/storefront/app/views/themes/default/spree/page_sections/nav/_desktop.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/nav/_desktop.html.erb
@@ -27,8 +27,8 @@
               <% if block.try(:featured_taxon) %>
                 <% cache spree_base_cache_scope.call(block.featured_taxon) do %>
                   <% if block.featured_taxon.image.attached? && block.featured_taxon.image.variable? %>
-                      <%= image_tag main_app.cdn_image_path(block.featured_taxon.image.variant(spree_image_variant_options(resize_to_fill: [700, 700]))), class: 'w-full h-auto aspect-1', loading: :lazy, alt: block.featured_taxon.name %>
                     <%= link_to spree_storefront_resource_url(block.featured_taxon, relative: true), class: "flex flex-col col-start-4" do %>
+                      <%= image_tag main_app.cdn_image_url(block.featured_taxon.image.variant(spree_image_variant_options(resize_to_fill: [700, 700]))), class: 'w-full h-auto aspect-1', loading: :lazy, alt: block.featured_taxon.name %>
                       <span class="py-3 px-2 bg-accent block uppercase text-sm tracking-widest font-semibold header--mega-nav-featured-taxon-title"><%= Spree.t(:explore_taxon, taxon_name: block.featured_taxon.name) %></span>
                     <% end %>
                   <% end %>

--- a/storefront/app/views/themes/default/spree/page_sections/nav/_desktop.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/nav/_desktop.html.erb
@@ -4,7 +4,7 @@
     <% main_link = presenter.main_link %>
     <% next unless main_link.present? %>
     <div class="header--nav-item group" <%= block_attributes(block, allowed_styles: ['padding-top', 'padding-bottom']) %>>
-      <%= active_link_to spree_storefront_resource_url(main_link.linkable || main_link), data: { title: main_link.label.downcase.strip }, class: "shrink-0 menu-item header--nav-link px-4 py-1", class_active: "menu-item--active", target: main_link.open_in_new_tab.presence && "_blank", rel: main_link.open_in_new_tab.presence && "noopener noreferrer" do %>
+      <%= active_link_to spree_storefront_resource_path(main_link.linkable || main_link), data: { title: main_link.label.downcase.strip }, class: "shrink-0 menu-item header--nav-link px-4 py-1", class_active: "menu-item--active", target: main_link.open_in_new_tab.presence && "_blank", rel: main_link.open_in_new_tab.presence && "noopener noreferrer" do %>
         <span class="group-hover:border-b-[1.5px] group-hover:border-b-accent"><%= main_link.label %></span>
       <% end %>
       <% if presenter.columns.any? %>
@@ -21,14 +21,14 @@
                       <% end %>
                     </div>
                   <% end %>
-                  <%= link_to Spree.t(:view_all), spree_storefront_resource_url(column.view_all_linkable), class: "py-3 px-2 uppercase text-sm inline-block tracking-widest font-semibold" %>
+                  <%= link_to Spree.t(:view_all), spree_storefront_resource_path(column.view_all_linkable), class: "py-3 px-2 uppercase text-sm inline-block tracking-widest font-semibold" %>
                 </div>
               <% end %>
               <% if block.try(:featured_taxon) %>
                 <% cache spree_base_cache_scope.call(block.featured_taxon) do %>
                   <% if block.featured_taxon.image.attached? && block.featured_taxon.image.variable? %>
-                    <%= link_to spree_storefront_resource_url(block.featured_taxon), class: "flex flex-col col-start-4" do %>
-                      <%= image_tag main_app.cdn_image_url(block.featured_taxon.image.variant(spree_image_variant_options(resize_to_fill: [700, 700]))), class: 'w-full h-auto aspect-1', loading: :lazy, alt: block.featured_taxon.name %>
+                    <%= link_to spree_storefront_resource_path(block.featured_taxon), class: "flex flex-col col-start-4" do %>
+                      <%= image_tag main_app.cdn_image_path(block.featured_taxon.image.variant(spree_image_variant_options(resize_to_fill: [700, 700]))), class: 'w-full h-auto aspect-1', loading: :lazy, alt: block.featured_taxon.name %>
                       <span class="py-3 px-2 bg-accent block uppercase text-sm tracking-widest font-semibold header--mega-nav-featured-taxon-title"><%= Spree.t(:explore_taxon, taxon_name: block.featured_taxon.name) %></span>
                     <% end %>
                   <% end %>
@@ -42,7 +42,7 @@
   <% end %>
 <% else %>
   <% section.links.each do |link| %>
-    <%= active_link_to spree_storefront_resource_url(link.linkable || link), data: { title: link.label.downcase.strip }, class: "shrink-0 menu-item header--nav-link px-4 py-1 focus:mx-0 focus:px-4", class_active: "menu-item--active", target: link.open_in_new_tab.presence && "_blank", rel: link.open_in_new_tab.presence && "noopener noreferrer", **link_attributes(link, as_html: false) do %>
+    <%= active_link_to spree_storefront_resource_path(link.linkable || link), data: { title: link.label.downcase.strip }, class: "shrink-0 menu-item header--nav-link px-4 py-1 focus:mx-0 focus:px-4", class_active: "menu-item--active", target: link.open_in_new_tab.presence && "_blank", rel: link.open_in_new_tab.presence && "noopener noreferrer", **link_attributes(link, as_html: false) do %>
       <span><%= link.label %></span>
     <% end %>
   <% end %>

--- a/storefront/app/views/themes/default/spree/page_sections/nav/_mobile.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/nav/_mobile.html.erb
@@ -23,7 +23,7 @@
                     <% if block.try(:featured_taxon) %>
                       <% cache spree_base_cache_scope.call(block.featured_taxon) do %>
                         <% if block.featured_taxon.image.attached? && block.featured_taxon.image.variable? %>
-                          <%= link_to spree_storefront_resource_url(block.featured_taxon), class: "flex w-full pt-4" do %>
+                          <%= link_to spree_storefront_resource_url(block.featured_taxon, relative: true), class: "flex w-full pt-4" do %>
                             <%= image_tag main_app.cdn_image_url(block.featured_taxon.image.variant(spree_image_variant_options(resize_to_fill: [280, 280]))), class: 'h-auto aspect-1 w-2/5 max-w-[140px]', loading: :lazy, alt: block.featured_taxon.name %>
                             <span class="bg-accent w-full flex items-center justify-center header--mega-nav-featured-taxon-title text-sm tracking-widest font-semibold uppercase">
                               <%= Spree.t(:explore_taxon, taxon_name: block.featured_taxon.name) %>


### PR DESCRIPTION
This pull request updates navigation links in the `storefront` theme to use `spree_storefront_resource_path` instead of `spree_storefront_resource_url`. This change ensures consistency in generating relative paths rather than full URLs, which can improve flexibility and compatibility in various deployment environments.

### Navigation Link Updates:

* Replaced `spree_storefront_resource_url` with `spree_storefront_resource_path` for the main navigation link in the desktop navigation menu. (`storefront/app/views/themes/default/spree/page_sections/nav/_desktop.html.erb`, [storefront/app/views/themes/default/spree/page_sections/nav/_desktop.html.erbL7-R7](diffhunk://#diff-f669d1e3147b84ad3532237852bd3d8e5f1203b364341f3a6d07ce0e40c10aa3L7-R7))
* Updated the "View All" link to use `spree_storefront_resource_path` instead of `spree_storefront_resource_url`. (`storefront/app/views/themes/default/spree/page_sections/nav/_desktop.html.erb`, [storefront/app/views/themes/default/spree/page_sections/nav/_desktop.html.erbL24-R31](diffhunk://#diff-f669d1e3147b84ad3532237852bd3d8e5f1203b364341f3a6d07ce0e40c10aa3L24-R31))
* Modified the link for featured taxons to use `spree_storefront_resource_path` and updated the image tag to use `cdn_image_path` instead of `cdn_image_url`. (`storefront/app/views/themes/default/spree/page_sections/nav/_desktop.html.erb`, [storefront/app/views/themes/default/spree/page_sections/nav/_desktop.html.erbL24-R31](diffhunk://#diff-f669d1e3147b84ad3532237852bd3d8e5f1203b364341f3a6d07ce0e40c10aa3L24-R31))
* Adjusted additional section links to use `spree_storefront_resource_path` for consistency. (`storefront/app/views/themes/default/spree/page_sections/nav/_desktop.html.erb`, [storefront/app/views/themes/default/spree/page_sections/nav/_desktop.html.erbL45-R45](diffhunk://#diff-f669d1e3147b84ad3532237852bd3d8e5f1203b364341f3a6d07ce0e40c10aa3L45-R45))